### PR TITLE
WP 5.3+ update

### DIFF
--- a/public/class-plyr-public.php
+++ b/public/class-plyr-public.php
@@ -105,7 +105,7 @@ class Plyr_Public {
 	public function embed_oembed_html( $html, $url, $attr, $post_ID ) {
 
 		$args = array();
-		include_once ABSPATH . WPINC . '/class-oembed.php';
+		include_once ABSPATH . WPINC . '/class-wp-oembed.php';
 
 		$wp_oembed = new WP_oEmbed();
 


### PR DESCRIPTION
Hi @sampotts,

this tiny patch replaces the usage of `class-oembed.php` by `class-wp-oembed.php` since the old one is [deprecated according to the WP-folks](https://github.com/WordPress/WordPress/blob/master/wp-includes/class-oembed.php).

Cheers,
Christian